### PR TITLE
add RedisMapCache.keys()

### DIFF
--- a/src/helpers/resolve-redis-instance.ts
+++ b/src/helpers/resolve-redis-instance.ts
@@ -1,9 +1,13 @@
 import Redis from "ioredis";
 
-export type RedisHost = string | Redis.RedisOptions | Redis.Redis;
-export function resolveRedisInstance(host: RedisHost, options?: Redis.RedisOptions): Redis.Redis {
+export type RedisLike = string | Redis.RedisOptions | Redis.Redis;
+export function resolveRedisInstance(host: RedisLike, options?: Redis.RedisOptions): Redis.Redis {
   if (host instanceof Redis || typeof Redis) return host as Redis.Redis;
   // host parameter being used as connection uri
   if (typeof host === "string") return new Redis(host, options);
+  if (options) {
+    throw new Error('"options" was defined when "host" should contain the options.');
+  }
+
   return new Redis(host);
 }

--- a/src/redis/base.redis.ts
+++ b/src/redis/base.redis.ts
@@ -1,10 +1,24 @@
 import { Redis, RedisOptions } from "ioredis";
-import { RedisHost, resolveRedisInstance } from "../helpers/resolve-redis-instance";
 import { Cache, Expiry } from "../cache";
+import { RedisLike, resolveRedisInstance } from "../helpers/resolve-redis-instance";
 
 export interface RedisCacheOptions extends RedisOptions {
+  /**
+   * The default expiry used for "set()" calls that do not explicitly set one.
+   */
   defaultExpiry?: Expiry;
-  enableExpensiveClear?: boolean;
+  /**
+   * Enable key tracking for this cache. This is required for the "clear()" and "keys()" methods.
+   *
+   * **This option can get computationally expensive** because it uses a separate set to keep track of the keys in this cache.
+   * You should only enable this option on caches that require it and are relatively small, otherwise the overhead would
+   * be too large for it to make sense.
+   *
+   * Keys added to the before this option was enabled cache will not be removed when
+   * calling "clear()" or show up in the "keys()" result because they would not be recorded.
+   * This also goes for other caches accessing the same namespace without this option enabled.
+   */
+  trackKeys?: boolean;
 }
 
 export abstract class RedisCache extends Cache {
@@ -12,17 +26,10 @@ export abstract class RedisCache extends Cache {
   protected readonly namespace: string;
   protected readonly options?: RedisCacheOptions;
 
-  constructor(host: RedisHost, namespace: string, options?: RedisCacheOptions) {
+  constructor(host: RedisLike, namespace: string, options?: RedisCacheOptions) {
     super(undefined, options?.defaultExpiry);
     this.options = options;
     this.namespace = namespace;
     this.redis = resolveRedisInstance(host, options);
-  }
-
-  protected async clear(namespace?: string): Promise<void> {
-    const key = namespace ?? this.namespace;
-    const members = await this.redis.smembers(key);
-    await this.redis.del(members.concat(key));
-    return;
   }
 }

--- a/src/redis/map.redis.ts
+++ b/src/redis/map.redis.ts
@@ -1,18 +1,35 @@
 import { Expiry } from "../cache";
-import { RedisHost } from "../helpers/resolve-redis-instance";
+import { RedisLike } from "../helpers/resolve-redis-instance";
 import { MapCache } from "../interfaces/map-cache.interface";
 import { SetOption } from "../types";
 import { RedisCache, RedisCacheOptions } from "./base.redis";
 
 export class RedisMapCache<Type> extends RedisCache implements MapCache<Type> {
-  private readonly enableClear?: boolean;
-  private readonly membersNamespace = `members:${this.namespace}`;
+  private readonly trackKeys?: boolean;
 
-  constructor(host: RedisHost, namespace: string, options?: RedisCacheOptions | Expiry) {
+  constructor(host: RedisLike, namespace: string, options?: RedisCacheOptions | Expiry) {
     super(host, namespace, RedisMapCache.resolveOptions(options));
-    this.enableClear = this.options?.enableExpensiveClear;
+    this.trackKeys = this.options?.trackKeys;
   }
 
+  /**
+   * Get the key for the members set, used to track which keys are in this cache.
+   * @throws if key tracking is not enabled
+   */
+  protected get membersSetKey() {
+    if (!this.trackKeys) {
+      throw new Error('The "trackKeys" option is required to use this method.');
+    }
+
+    // the additional prefix here is important so we dont accidentally obliterate
+    // an unrelated key. if the namespace was "balls" and someone created a key
+    // called "balls" with an unrelated value, clearing the cache would wipe their key.
+    return `kas:members:${this.namespace}`;
+  }
+
+  /**
+   * Get a keys value from the cache.
+   */
   public async get(key: string): Promise<Type | undefined> {
     const prefixedKey = this.getPrefixedKey(key);
     const stringified = await this.redis.get(prefixedKey);
@@ -20,6 +37,9 @@ export class RedisMapCache<Type> extends RedisCache implements MapCache<Type> {
     return JSON.parse(stringified);
   }
 
+  /**
+   * Add an item to the cache.
+   */
   public async set(key: string, data: Type, ttl?: Expiry, mode?: SetOption): Promise<boolean> {
     if (data == null) return false;
     const prefixedKey = this.getPrefixedKey(key);
@@ -33,34 +53,61 @@ export class RedisMapCache<Type> extends RedisCache implements MapCache<Type> {
     }
 
     if (mode) params.push(mode);
-    if (this.enableClear) await this.redis.sadd(this.membersNamespace, prefixedKey);
-    await this.redis.set(...params);
+    if (this.trackKeys) {
+      await this.redis
+        .pipeline()
+        .sadd(this.membersSetKey, key)
+        .set(...params)
+        .exec();
+    } else {
+      await this.redis.set(...params);
+    }
+
     return true;
   }
 
+  /**
+   * Delete a key from the cache.
+   */
+  public async delete(key: string): Promise<boolean> {
+    const prefixedKey = this.getPrefixedKey(key);
+    if (this.trackKeys) {
+      await this.redis.pipeline().srem(this.membersSetKey, key).del(prefixedKey).exec();
+    } else {
+      await this.redis.del(prefixedKey);
+    }
+
+    return true;
+  }
+
+  /**
+   * Check if the cache has a key.
+   */
   public async has(key: string): Promise<boolean> {
     const prefixedKey = this.getPrefixedKey(key);
     const exists = await this.redis.exists(prefixedKey);
     return exists === 1 ? true : false;
   }
 
-  public async delete(key: string): Promise<boolean> {
-    const prefixedKey = this.getPrefixedKey(key);
-    if (this.enableClear) await this.redis.srem(this.membersNamespace, prefixedKey);
-    await this.redis.del(prefixedKey);
-    return true;
-  }
-
+  /**
+   * Clear all options in the cache.
+   * @throws if the "trackKeys" option is not enabled.
+   */
   public async clear(): Promise<void> {
-    if (!this.enableClear)
-      throw new Error(
-        "Enable expensive clear option to clear redis caches. Please keep in mind, previously set key-value pairs will not be cleared."
-      );
-    // important so we don't unintentionally obliterate an unrelated set
-    return super.clear(this.membersNamespace);
+    const members = await this.redis.smembers(this.membersSetKey);
+    const keys = members.map((key) => this.getPrefixedKey(key)).concat(this.membersSetKey);
+    await this.redis.del(...keys);
   }
 
-  static resolveOptions(options?: RedisCacheOptions | Expiry) {
+  /**
+   * Gets all keys in the cache.
+   * @throws if the "trackKeys" option is not enabled.
+   */
+  public async keys(): Promise<string[]> {
+    return this.redis.smembers(this.membersSetKey);
+  }
+
+  protected static resolveOptions(options?: RedisCacheOptions | Expiry) {
     if (typeof options === "string" || typeof options === "number") return { defaultExpiry: options };
     return options;
   }

--- a/src/redis/map.test.ts
+++ b/src/redis/map.test.ts
@@ -22,7 +22,7 @@ describe("Kas Redis Map Cache", () => {
     expect(await cache.get("test")).toBeUndefined();
   });
   test("Should clear all cached data", async () => {
-    const cache = new RedisMapCache<string>(client, "fortnite", { enableExpensiveClear: true });
+    const cache = new RedisMapCache<string>(client, "fortnite", { trackKeys: true });
     expect(await cache.set("test", "epic")).toBeTruthy();
     expect(await cache.get("test")).toBe("epic");
     expect(await cache.clear()).toBeUndefined();
@@ -38,5 +38,16 @@ describe("Kas Redis Map Cache", () => {
   test('Should allow the "options" parameter to be a expiry string', async () => {
     const cache = new RedisMapCache<string>(client, "fortnite", "5s");
     expect((cache as any).defaultExpiry).toBe(5000);
+  });
+  it('should return a list of keys from the "keys" method', async () => {
+    const cache = new RedisMapCache<string>(client, "fortnite", { trackKeys: true });
+    await cache.set("test1", "epic");
+    expect(await cache.keys()).toEqual(["test1"]);
+    await cache.set("test2", "epic");
+    expect(await cache.keys()).toEqual(["test1", "test2"]);
+    await cache.delete("test1");
+    expect(await cache.keys()).toEqual(["test2"]);
+    await cache.clear();
+    expect(await cache.keys()).toEqual([]);
   });
 });

--- a/src/redis/set.redis.ts
+++ b/src/redis/set.redis.ts
@@ -2,6 +2,9 @@ import { SetCache } from "../interfaces/set-cache.interface";
 import { RedisCache } from "./base.redis";
 
 export class RedisSetCache<Type> extends RedisCache implements SetCache<Type> {
+  /**
+   * Add an item to the set.
+   */
   public async add(data: Type): Promise<boolean> {
     if (data == null) return false;
     const stringified = JSON.stringify(data);
@@ -9,6 +12,9 @@ export class RedisSetCache<Type> extends RedisCache implements SetCache<Type> {
     return true;
   }
 
+  /**
+   * Check whether the set has an item.
+   */
   public async has(data: Type): Promise<boolean> {
     if (data == null) return false;
     const stringified = JSON.stringify(data);
@@ -16,6 +22,9 @@ export class RedisSetCache<Type> extends RedisCache implements SetCache<Type> {
     return exists === 1 ? true : false;
   }
 
+  /**
+   * Delete an item from the set.
+   */
   public async delete(data: Type): Promise<boolean> {
     if (data == null) return false;
     const stringified = JSON.stringify(data);
@@ -23,7 +32,10 @@ export class RedisSetCache<Type> extends RedisCache implements SetCache<Type> {
     return true;
   }
 
+  /**
+   * Clear all items in the set.
+   */
   public async clear(): Promise<void> {
-    return super.clear();
+    await this.redis.del(this.namespace);
   }
 }


### PR DESCRIPTION
This adds a new "keys()" method to RedisMapCache instances. It uses essentially the same method as RedisMapCache.clear() using a set but I updated it to be a bit more flexible. I ended up renaming "enableExpensiveClear" to "trackKeys" as its more generic and I feel fits better, but that does break backwards compatibility. I added jsdoc info to the key to explain its uses, and changed the members key slightly to intentionally break backwards compatibility as keys in the set are no longer prefixed ~~and I wanted to~~.